### PR TITLE
[TTS] FastPitch tutorial - Add pynini installation

### DIFF
--- a/tts-finetune-nemo.ipynb
+++ b/tts-finetune-nemo.ipynb
@@ -57,9 +57,9 @@
    "source": [
     "After [installing NeMo](https://github.com/NVIDIA/NeMo#installation), the next step is to setup the paths to save data and results. NeMo can be used with docker containers or virtual environments.\n",
     "\n",
-    "Replace the variables FIXME with the required paths enclosed in `\"\"` as a string.\n",
+    "Replace the variables FIXME with the required paths enclosed in \"\" as a string.\n",
     "\n",
-    "`IMPORTANT NOTE:` Here, we map directories in which we save the data, specs, results and cache. You should configure it for your specific case so these directories are correctly visible to the docker container."
+    "`IMPORTANT NOTE:` Here, we map directories in which we save the data, specs, results and cache. You should configure it for your specific case so these directories are correctly visible to the docker container. Make sure this tutorial is in the NeMo folder."
    ]
   },
   {
@@ -101,7 +101,10 @@
     "!pip install nemo_toolkit['all']\n",
     "!ngc registry resource download-version \"nvidia/riva/riva_quickstart:2.8.1\"\n",
     "!pip install \"riva_quickstart_v2.8.1/nemo2riva-2.8.1-py3-none-any.whl\"\n",
-    "!pip install protobuf==3.20.0"
+    "!pip install protobuf==3.20.0\n",
+    "# Installing pynini separately\n",
+    "!wget https://raw.githubusercontent.com/NVIDIA/NeMo/main/nemo_text_processing/install_pynini.sh \\\n",
+    "bash install_pynini.sh"
    ]
   },
   {


### PR DESCRIPTION
Signed-off-by: subhankar-ghosh <subhankar2321@gmail.com>

pynini was removed from our NeMo requirements. If nemo is not installed using docker, pynini needs to be separately installed, this PR adds this installation command.