### PR TITLE
Fix installs for TTS notebooks

### DIFF
--- a/tts-finetune-nemo.ipynb
+++ b/tts-finetune-nemo.ipynb
@@ -102,9 +102,7 @@
     "!ngc registry resource download-version \"nvidia/riva/riva_quickstart:2.8.1\"\n",
     "!pip install \"riva_quickstart_v2.8.1/nemo2riva-2.8.1-py3-none-any.whl\"\n",
     "!pip install protobuf==3.20.0\n",
-    "# Installing pynini separately\n",
-    "!wget https://raw.githubusercontent.com/NVIDIA/NeMo/main/nemo_text_processing/install_pynini.sh \\\n",
-    "bash install_pynini.sh"
+    "!pip install pynini==2.1.5"
    ]
   },
   {

--- a/tts-phoneme-distribution.ipynb
+++ b/tts-phoneme-distribution.ipynb
@@ -31,7 +31,8 @@
    "outputs": [],
    "source": [
     "!pip install bokeh cmudict prettytable nemo_toolkit['all']\n",
-    "!pip install protobuf==3.20.0"
+    "!pip install protobuf==3.20.0\n",
+    "!pip install nemo_text_processing"
    ]
   },
   {


### PR DESCRIPTION
Added necessary `nemo_text_processing` install to one notebook, and manually pinned `pynini` version in another since the install script has been removed from NeMo.