### PR TITLE
Fix rendering of figure in TTS phoneme distribution tutorial on the Riva docs page

### DIFF
--- a/tts-phoneme-distribution.ipynb
+++ b/tts-phoneme-distribution.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "4d21f599",
    "metadata": {},
@@ -483,7 +482,7 @@
    "id": "a23f06d1",
    "metadata": {},
    "source": [
-    "<img src=\"imgs/riva-tts-phoneme-distribution-comparison.png\">"
+    "<img src=\"https://github.com/nvidia-riva/tutorials/blob/main/imgs/riva-tts-phoneme-distribution-comparison.png?raw=true\">"
    ]
   },
   {
@@ -535,9 +534,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "virtualenv-riva-tutorials-py38",
    "language": "python",
-   "name": "python3"
+   "name": "virtualenv-riva-tutorials-py38"
   },
   "language_info": {
    "codemirror_mode": {
@@ -549,7 +548,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Attempting to fix an issue of a figure not rendering properly on the Riva docs page by changing the image source path from imgs/riva-tts-phoneme-distribution-comparison.png to https://github.com/nvidia-riva/tutorials/blob/main/imgs/riva-tts-phoneme-distribution-comparison.png?raw=true