### PR TITLE
Updated the installation command for the flashlight-text module in the ASR LM training tutorial

### DIFF
--- a/asr-python-advanced-nemo-ngram-training-and-finetuning.ipynb
+++ b/asr-python-advanced-nemo-ngram-training-and-finetuning.ipynb
@@ -118,7 +118,7 @@
         "!cd kenlm && mkdir build && cd build && cmake .. && make -j\n",
         "\n",
         "!pip3 install git+https://github.com/kpu/kenlm.git\n",
-        "!pip3 install git+https://github.com/flashlight/text.git"
+        "!pip3 install flashlight-text"
       ]
     },
     {


### PR DESCRIPTION
flashlight-text is now available on PyPI. The old method of installing it with pip install git+ now results in an error, so I changed it to pip3 install flashlight-text.