### PR TITLE
Tts deploy doc update

### DIFF
--- a/tts-deploy.ipynb
+++ b/tts-deploy.ipynb
@@ -79,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "579b6420",
    "metadata": {},
    "outputs": [],
@@ -130,9 +130,10 @@
     "            f\"notebook. NGC message: {ngc_output_formatted}\"\n",
     "        )\n",
     "        return None\n",
-    "    riva_files_in_dir = list(output.glob(\"*.riva\"))\n",
-    "    if len(riva_files_in_dir) > 0:\n",
-    "        output = riva_files_in_dir[0]\n",
+    "    if \"model\" in resource_type:\n",
+    "        riva_files_in_dir = list(output.glob(\"*.riva\"))\n",
+    "        if len(riva_files_in_dir) > 0:\n",
+    "            output = riva_files_in_dir[0]\n",
     "    if output is not None and var is not None:\n",
     "        warnings.warn(\n",
     "            f\"`{var_name}` had a non-default value of `{var}`. `{var_name}` will be updated to `{var}`\"\n",
@@ -536,7 +537,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.0"
   },
   "vscode": {
    "interpreter": {

--- a/tts-finetune-nemo.ipynb
+++ b/tts-finetune-nemo.ipynb
@@ -671,10 +671,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "hifigan_full_ds = f\"{finetune_data_path}/mels/merged_full_mel.json\"\n",
     "hifigan_train_ds = f\"{finetune_data_path}/mels/merged_train_mel.json\"\n",
     "hifigan_val_ds = f\"{finetune_data_path}/mels/merged_val_mel.json\"\n",
     "\n",
-    "! cat {hifigan_train_ds} | tail -n 2 > {hifigan_val_ds}"
+    "! cat {hifigan_train_ds} > {hifigan_full_ds}\n",
+    "! cat {hifigan_full_ds} | tail -n 2 > {hifigan_val_ds}\n",
+    "! cat {hifigan_full_ds} | head -n -2 > {hifigan_train_ds}"
    ]
   },
   {
@@ -878,7 +881,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -893,7 +895,7 @@
    "hash": "741d73fab70d7eb29e7b56260ebaa567f0620f4d2780830ca385f600e5120e14"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -907,7 +909,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixed minor issues in 
- tts_deploy: Fixed a bug in ngc_download_and_get_dir, which was not returning the directory in case of artefacts and .riva checkpoint path in case of models.
- tts_finetune_nemo: Removed train and validation dataset overlap.