### PR TITLE
asr: add tutorial demonstrating client-side force_eou

### DIFF
--- a/asr-force-eou.ipynb
+++ b/asr-force-eou.ipynb
@@ -1,0 +1,482 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "md-0",
+   "metadata": {},
+   "source": [
+    "<img src=\"https://developer.download.nvidia.com/notebooks/dlsw-notebooks/rivaasrasr-basics/nvidia_logo.png\" style=\"width: 90px; float: right;\">\n",
+    "\n",
+    "# How do I force an end-of-utterance from the client side?\n",
+    "\n",
+    "This tutorial shows how to use the `force_eou` runtime flag to make the Riva ASR NIM finalize the current partial transcript on demand &mdash; without closing the stream &mdash; using the **Nemotron ASR Streaming** (cache-aware RNNT) NIM. <br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-1",
+   "metadata": {},
+   "source": [
+    "## Why force end-of-utterance?\n",
+    "\n",
+    "By default, Riva detects end-of-utterance (EOU) on the server using a silence-based timer (typically several hundred milliseconds of trailing silence before the final transcript is emitted). That works well, but a real-time agent often has *better information* than the server &mdash; for example:\n",
+    "\n",
+    "- A push-to-talk button release\n",
+    "- A turn-taking signal from a conversational agent\n",
+    "- A client-side voice activity detector that is faster or more aggressive than the server's\n",
+    "- An LLM deciding \"I have what I need, finalize now\"\n",
+    "\n",
+    "The `force_eou` flag is an extension point for these cases. The client sets it on a particular audio chunk; the server flushes the current utterance immediately, emits a final transcript, and **keeps the stream open** so subsequent audio continues as a new utterance.\n",
+    "\n",
+    "In this tutorial we use a simple client-side silence detector (RMS energy) as a ***proxy*** for those higher-level signals so that the demo is fully self-contained.\n",
+    "\n",
+    "> **Model support:** `force_eou` is currently honored only by **Nemotron ASR Streaming**. <br>This feature will not work with **Parakeet-CTC** and **Parakeet-RNNT** NIMs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-2",
+   "metadata": {},
+   "source": [
+    "## Requirements and setup\n",
+    "\n",
+    "1. **Start the Nemotron ASR Streaming NIM server.**\n",
+    "   Follow the [Riva NIM getting started guide](https://docs.nvidia.com/nim/speech/latest/about/index.html#launching-the-nim) to launch the NIM. Use:\n",
+    "   - `CONTAINER_ID = nemotron-asr-streaming`\n",
+    "   - `NIM_TAGS_SELECTOR = \"name=nemotron-asr-streaming,mode=str\"`\n",
+    "\n",
+    "   The NIM exposes gRPC on port `50051` \n",
+    "\n",
+    "2. **Install the Riva Client library.**\n",
+    "   ```bash\n",
+    "   sudo apt-get install python3-pip\n",
+    "   pip install -U nvidia-riva-client\n",
+    "   ```\n",
+    "\n",
+    "   This tutorial uses the `runtime_config` field on `StreamingRecognizeRequest` (proto `map<string, string>`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-3",
+   "metadata": {},
+   "source": [
+    "#### Import the Riva client libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code-4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import io\n",
+    "import time\n",
+    "import wave\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import IPython.display as ipd\n",
+    "\n",
+    "import riva.client\n",
+    "import riva.client.proto.riva_asr_pb2 as rasr\n",
+    "import riva.client.proto.riva_asr_pb2_grpc as rasr_grpc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-5",
+   "metadata": {},
+   "source": [
+    "#### Connect to the Riva NIM server\n",
+    "\n",
+    "The default URI assumes a local NIM deployment on port `50051`. Adjust if your server is remote or behind a Helm chart."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code-6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auth = riva.client.Auth(uri='localhost:50051')\n",
+    "asr_stub = rasr_grpc.RivaSpeechRecognitionStub(auth.channel)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-7",
+   "metadata": {},
+   "source": [
+    "## Choose a test audio sample\n",
+    "\n",
+    "We use the existing `audio_samples/en-US_wordboosting_sample2.wav` clip, which contains two natural utterances separated by a brief mid-clip pause. The pause is short enough that the server's default endpointing threshold won't fire a mid-stream final on its own, making the effect of `force_eou` clearly visible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code-8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "AUDIO_PATH = Path(\"audio_samples/en-US_wordboosting_sample2.wav\")\n",
+    "\n",
+    "with wave.open(str(AUDIO_PATH), 'rb') as w:\n",
+    "    params = w.getparams()\n",
+    "\n",
+    "print(f\"Sample rate    : {params.framerate} Hz\")\n",
+    "print(f\"Channels       : {params.nchannels}\")\n",
+    "print(f\"Total duration : {params.nframes / params.framerate:.2f} s\")\n",
+    "ipd.Audio(str(AUDIO_PATH))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-9",
+   "metadata": {},
+   "source": [
+    "## Streaming recognition config\n",
+    "\n",
+    "We use the same config for both runs (with and without `force_eou`) so the only variable is the client trigger. Server-side endpointing is left at its default; on Nemotron ASR Streaming the silence threshold is around 800 ms: long enough that a 200 ms client trigger will visibly preempt it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code-10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "streaming_config = rasr.StreamingRecognitionConfig(\n",
+    "    config=rasr.RecognitionConfig(\n",
+    "        encoding=riva.client.AudioEncoding.LINEAR_PCM,\n",
+    "        sample_rate_hertz=params.framerate,\n",
+    "        audio_channel_count=1,\n",
+    "        language_code=\"en-US\",\n",
+    "        max_alternatives=1,\n",
+    "        enable_automatic_punctuation=True,\n",
+    "    ),\n",
+    "    interim_results=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-11",
+   "metadata": {},
+   "source": [
+    "## Helper: collect responses with arrival timestamps\n",
+    "\n",
+    "To compare runs, we record the wall-clock time at which each **final** transcript arrives, measured from the start of the streaming call. This lets us see how much earlier `force_eou` finalizes the first utterance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code-12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "CHUNK_FRAMES = 1600  # 100 ms at 16 kHz; the silence detector buffers internally,\n",
+    "                     # so any chunk size is fine -- this just controls how often\n",
+    "                     # we hand a chunk to the gRPC stream.\n",
+    "\n",
+    "\n",
+    "def collect_finals(response_iterator, t0, force_eou_sends=None, max_match_delay_s=1.0):\n",
+    "    \"\"\"Print partials inline and yield (elapsed_s, transcript) for each final.\n",
+    "\n",
+    "    If `force_eou_sends` (a deque of wall-clock timestamps) is provided, each\n",
+    "    final is matched against the oldest pending send, and the delay is printed.\n",
+    "    Sends older than `max_match_delay_s` are aged out -- this handles spurious\n",
+    "    force_eou signals that the server silently dropped (e.g., when no speech\n",
+    "    was buffered yet).\n",
+    "    \"\"\"\n",
+    "    for response in response_iterator:\n",
+    "        for result in response.results:\n",
+    "            if not result.alternatives:\n",
+    "                continue\n",
+    "            transcript = result.alternatives[0].transcript\n",
+    "            now = time.monotonic()\n",
+    "            elapsed = now - t0\n",
+    "            if result.is_final:\n",
+    "                delay_str = \"\"\n",
+    "                if force_eou_sends is not None:\n",
+    "                    while force_eou_sends and now - force_eou_sends[0] > max_match_delay_s:\n",
+    "                        force_eou_sends.popleft()\n",
+    "                    if force_eou_sends:\n",
+    "                        send_t = force_eou_sends.popleft()\n",
+    "                        delay_str = f\" (+{(now - send_t) * 1000:.0f} ms after force_eou)\"\n",
+    "                print(f\"[final   t={elapsed:5.2f}s]{delay_str} {transcript!r}\")\n",
+    "                yield elapsed, transcript\n",
+    "            else:\n",
+    "                print(f\"[partial t={elapsed:5.2f}s] {transcript!r}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-13",
+   "metadata": {},
+   "source": [
+    "## Run 1 &mdash; baseline (no `force_eou`)\n",
+    "\n",
+    "The audio is streamed in real time (`sleep_audio_length` throttles the iterator). The server's own silence-based endpointing is the only thing that can produce mid-stream finals."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code-14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def baseline_request_generator(streaming_config, chunks):\n",
+    "    yield rasr.StreamingRecognizeRequest(streaming_config=streaming_config)\n",
+    "    for chunk in chunks:\n",
+    "        yield rasr.StreamingRecognizeRequest(audio_content=chunk)\n",
+    "\n",
+    "\n",
+    "print(\"--- baseline run (no force_eou) ---\")\n",
+    "with riva.client.AudioChunkFileIterator(\n",
+    "    str(AUDIO_PATH), CHUNK_FRAMES, delay_callback=riva.client.sleep_audio_length\n",
+    ") as chunks:\n",
+    "    t0 = time.monotonic()\n",
+    "    responses = asr_stub.StreamingRecognize(\n",
+    "        baseline_request_generator(streaming_config, chunks),\n",
+    "        metadata=auth.get_auth_metadata(),\n",
+    "    )\n",
+    "    baseline_finals = list(collect_finals(responses, t0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-15",
+   "metadata": {},
+   "source": [
+    "## Helper: client-side silence detector\n",
+    "\n",
+    "A minimal RMS-based detector. Audio chunks are split into 20 ms windows; we count consecutive low-RMS windows. After 200 ms of continuous silence following speech, we fire `force_eou=True` **once** for that silence event &mdash; subsequent silent chunks are suppressed until the next speech&rarr;silence transition. This matches how real applications would emit a single edge-triggered finalize signal."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code-16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class SilenceDetector:\n",
+    "    \"\"\"Edge-triggered silence detector. Fires once per speech->silence transition.\n",
+    "\n",
+    "    Buffers audio internally so it works regardless of caller chunk size; the\n",
+    "    only requirement is that the analysis window (default 20 ms) fits within\n",
+    "    the audio stream as a whole.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    def __init__(\n",
+    "        self,\n",
+    "        sample_rate: int,\n",
+    "        window_ms: int = 20,\n",
+    "        silence_threshold_ms: int = 200,\n",
+    "        rms_threshold: float = 300.0,\n",
+    "    ):\n",
+    "        self.window_ms = window_ms\n",
+    "        self.window_samples = int(sample_rate * window_ms / 1000)\n",
+    "        self.windows_needed = silence_threshold_ms // window_ms\n",
+    "        self.rms_threshold = rms_threshold\n",
+    "        self.consec_silent = 0\n",
+    "        self.windows_processed = 0  # tracks audio-time position\n",
+    "        self.in_speech = False\n",
+    "        self.fired_for_current_silence = False\n",
+    "        self.buffer = np.empty(0, dtype=np.int16)  # leftover samples between chunks\n",
+    "\n",
+    "    def process_chunk(self, chunk_bytes: bytes) -> bool:\n",
+    "        new_samples = np.frombuffer(chunk_bytes, dtype=np.int16)\n",
+    "        samples = np.concatenate([self.buffer, new_samples])\n",
+    "        n_windows = len(samples) // self.window_samples\n",
+    "        fired = False\n",
+    "        for i in range(n_windows):\n",
+    "            self.windows_processed += 1\n",
+    "            window = samples[i * self.window_samples:(i + 1) * self.window_samples].astype(np.float32)\n",
+    "            rms = float(np.sqrt(np.mean(window ** 2)))\n",
+    "            if rms < self.rms_threshold:\n",
+    "                self.consec_silent += 1\n",
+    "            else:\n",
+    "                self.consec_silent = 0\n",
+    "                self.in_speech = True\n",
+    "                self.fired_for_current_silence = False\n",
+    "            if (\n",
+    "                self.in_speech\n",
+    "                and not self.fired_for_current_silence\n",
+    "                and self.consec_silent >= self.windows_needed\n",
+    "            ):\n",
+    "                self.fired_for_current_silence = True\n",
+    "                silence_ms = self.consec_silent * self.window_ms\n",
+    "                silence_end = self.windows_processed * self.window_ms / 1000.0\n",
+    "                silence_start = silence_end - silence_ms / 1000.0\n",
+    "                print(\n",
+    "                    f\"[silence detector] {silence_ms} ms silence in audio \"\n",
+    "                    f\"[{silence_start:.2f}s, {silence_end:.2f}s] -- \"\n",
+    "                    f\"force_eou sent at audio t={silence_end:.2f}s\"\n",
+    "                )\n",
+    "                fired = True\n",
+    "        # carry leftover samples (less than one window) into the next call\n",
+    "        self.buffer = samples[n_windows * self.window_samples:]\n",
+    "        return fired"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-17",
+   "metadata": {},
+   "source": [
+    "## Run 2 &mdash; with `force_eou`\n",
+    "\n",
+    "The request generator inspects each outgoing chunk with `SilenceDetector` and sets `runtime_config={\"force_eou\": \"true\"}` on the chunk where the silence boundary is crossed. No SDK changes are required &mdash; `runtime_config` is a generic `map<string, string>` on `StreamingRecognizeRequest`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code-18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from collections import deque\n",
+    "\n",
+    "\n",
+    "def force_eou_request_generator(streaming_config, chunks, detector, send_log):\n",
+    "    yield rasr.StreamingRecognizeRequest(streaming_config=streaming_config)\n",
+    "    for chunk in chunks:\n",
+    "        force = detector.process_chunk(chunk)\n",
+    "        if force:\n",
+    "            send_log.append(time.monotonic())\n",
+    "        runtime_config = {\"force_eou\": \"true\"} if force else {}\n",
+    "        yield rasr.StreamingRecognizeRequest(\n",
+    "            audio_content=chunk,\n",
+    "            runtime_config=runtime_config,\n",
+    "        )\n",
+    "\n",
+    "\n",
+    "detector = SilenceDetector(sample_rate=params.framerate)\n",
+    "force_eou_sends = deque()  # wall-clock times of force_eou sends, consumed by collect_finals\n",
+    "\n",
+    "print(\"--- force_eou run ---\")\n",
+    "with riva.client.AudioChunkFileIterator(\n",
+    "    str(AUDIO_PATH), CHUNK_FRAMES, delay_callback=riva.client.sleep_audio_length\n",
+    ") as chunks:\n",
+    "    t0 = time.monotonic()\n",
+    "    responses = asr_stub.StreamingRecognize(\n",
+    "        force_eou_request_generator(streaming_config, chunks, detector, force_eou_sends),\n",
+    "        metadata=auth.get_auth_metadata(),\n",
+    "    )\n",
+    "    force_eou_finals = list(collect_finals(responses, t0, force_eou_sends=force_eou_sends))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acfa353c",
+   "metadata": {},
+   "source": [
+    "### Reading the silence-detector log\n",
+    "\n",
+    "The detector printed three fires on the force_eou run, but only **two** finals were emitted by the server. Here is what each line means:\n",
+    "\n",
+    "- `200 ms silence in audio [0.02s, 0.22s] -- force_eou sent at audio t=0.22s` &mdash; a brief noisy sample at the very start of the clip crossed the RMS threshold for one 20 ms window, marking the detector as \"in speech,\" and the next 200 ms of quiet then satisfied the silence rule. **No final transcript was emitted in response.** This is by design: the cache-aware RNNT decoder honors `force_eou` only after speech has actually been collected for the current utterance. A premature signal is silently dropped, so clients can run aggressive detectors without producing phantom finals.\n",
+    "- `200 ms silence in audio [1.72s, 1.92s]` &mdash; the natural pause after \"asleep\". The server has buffered real speech, so it finalizes that utterance and emits the first final at wall clock t=2.06s.\n",
+    "- `200 ms silence in audio [4.26s, 4.46s]` &mdash; the trailing pause after \"door\". The server finalizes the second utterance at wall clock t=4.61s.\n",
+    "\n",
+    "Audio timestamps in the silence log are positions **within the wav file** (not wall-clock arrival time at the server). The `t=...s` in the partial / final lines is wall-clock relative to the start of the streaming call. The two should track each other closely because we throttle audio to real time with `sleep_audio_length`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-19",
+   "metadata": {},
+   "source": [
+    "## Comparison\n",
+    "\n",
+    "With server-side endpointing alone, the server waits for its silence threshold (around several hundred milliseconds) before producing a mid-stream final &mdash; for short pauses, that often means the entire input lands as one final at the end of the stream. With `force_eou`, the client triggers finalization after **200 ms** of detected silence, producing an earlier per-utterance final while the stream stays open for the next utterance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "code-20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"{'Run':<22} {'First final at':<18} {'Transcript':<60}\")\n",
+    "print(\"-\" * 100)\n",
+    "\n",
+    "\n",
+    "def first_final(records):\n",
+    "    return records[0] if records else (float('nan'), '<none>')\n",
+    "\n",
+    "\n",
+    "t_b, txt_b = first_final(baseline_finals)\n",
+    "t_f, txt_f = first_final(force_eou_finals)\n",
+    "print(f\"{'baseline':<22} {f'{t_b:.2f}s':<18} {txt_b!r}\")\n",
+    "print(f\"{'force_eou (200 ms)':<22} {f'{t_f:.2f}s':<18} {txt_f!r}\")\n",
+    "print()\n",
+    "if force_eou_finals and baseline_finals:\n",
+    "    print(f\"force_eou preempted the server-side EOU by {t_b - t_f:.2f} s on the first utterance.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-21",
+   "metadata": {},
+   "source": [
+    "## Production considerations\n",
+    "\n",
+    "- **RMS is a stand-in.** A 200 ms threshold is aggressive &mdash; natural mid-sentence pauses (breath, hesitation, \"uh\") often exceed 200 ms. Use a longer threshold, an external VAD, or higher-level signals (push-to-talk, agent decisions) in real applications.\n",
+    "- **Edge-triggered, not level-triggered.** `force_eou` is best modeled as a one-shot finalize event. The detector here fires once per speech&rarr;silence transition and suppresses repeats; sending `force_eou=true` on every chunk during a silence is harmless on the server but conceptually wrong.\n",
+    "- **Model gating.** `force_eou` is currently honored only by cache-aware RNNT models (e.g., Nemotron ASR Streaming). Other decoders silently ignore the flag.\n",
+    "- **Detection is decoupled from chunk size.** `SilenceDetector` buffers samples internally, so client chunk size doesn't constrain silence resolution &mdash; smaller chunks just mean more requests on the wire.\n",
+    "- **`force_eou` latency depends on chunk sizes.** The `+ms after force_eou` delay reported above is bounded primarily by the **server's processing chunk size**: the server can only act on the flag at its next chunk boundary. When the client chunk size is smaller than the server's, the wait time falls in the range `[0, server_chunk_size]` (plus network RTT and a small decoder-flush overhead). Larger client chunks introduce their own buffering delay before the flag even reaches the server."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-22",
+   "metadata": {},
+   "source": [
+    "## Go deeper into Riva capabilities\n",
+    "\n",
+    "### Additional Riva tutorials\n",
+    "\n",
+    "Check out more Riva tutorials [here](https://github.com/nvidia-riva/tutorials) for advanced features &mdash; word boosting, speaker diarization, custom vocabularies, and pipeline customization.\n",
+    "\n",
+    "### Additional resources\n",
+    "\n",
+    "- [Riva ASR NIM documentation](https://docs.nvidia.com/nim/speech/latest/asr/index.html)\n",
+    "- [Riva ASR NIM support matrix](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/asr.html)\n",
+    "- [Streaming ASR proto reference](https://docs.nvidia.com/nim/speech/latest/reference/api-references/asr/protos.html#riva-proto-riva-asr-proto)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Compares baseline streaming to a run where a client-side RMS silence detector sets runtime_config[force_eou]=true on speech->silence transitions. Targets Nemotron ASR Streaming (cache-aware RNNT).